### PR TITLE
fix bug in invalid_event

### DIFF
--- a/mosquitto-1.4.8/src/epoll_loop.c
+++ b/mosquitto-1.4.8/src/epoll_loop.c
@@ -62,7 +62,7 @@ void destory_epoll(struct mosquitto_db * db)
     }
 }
 
-int invalid_event(int state)
+int invalid_event(unsigned int state)
 {
     if(state > EPOLLET || state < EPOLLIN)
         return -1;

--- a/mosquitto-1.4.8/src/epoll_loop.h
+++ b/mosquitto-1.4.8/src/epoll_loop.h
@@ -52,7 +52,7 @@ void epoll_do_disconnect(struct mosquitto_db *db, struct mosquitto *context);
 int create_epoll(struct mosquitto_db *db);
 void destory_epoll(struct mosquitto_db *db);
 
-int invalid_event(int state);
+int invalid_event(unsigned int state);
 int register_event(struct mosquitto_db * db,int fd,int state);
 int unregister_event(struct mosquitto_db * db,int fd);
 int modify_event(struct mosquitto_db * db,int fd,int state);


### PR DESCRIPTION
On RedHat 6.5_x86_64, EPOLLET is treated as a negative number, this condition always return -1.
